### PR TITLE
Make design responsive, to properly support tablets and foldables

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -94,6 +94,15 @@ class EduMFAAuthenticator extends ConsumerWidget {
                 brightness: Brightness.dark,
               ));
             }
+            final navigationRailThemeData = NavigationRailThemeData(
+              backgroundColor: Colors.black,
+              unselectedLabelTextStyle: TextStyle(color: darkTheme.colorScheme.onSurface),
+              selectedLabelTextStyle: TextStyle(color: darkTheme.colorScheme.onSurface),
+              selectedIconTheme: darkTheme.iconTheme,
+              unselectedIconTheme: darkTheme.iconTheme,
+              indicatorColor: darkTheme.colorScheme.secondaryContainer
+            );
+            lightTheme = lightTheme.copyWith(navigationRailTheme: navigationRailThemeData);
 
             return MaterialApp(
               debugShowCheckedModeBanner: true,

--- a/lib/views/main_view/main_view.dart
+++ b/lib/views/main_view/main_view.dart
@@ -1,9 +1,11 @@
 import 'package:edumfa_authenticator/generated/l10n.dart';
 import 'package:edumfa_authenticator/utils/logger.dart';
 import 'package:edumfa_authenticator/utils/riverpod_providers.dart';
+import 'package:edumfa_authenticator/utils/utils.dart';
 import 'package:edumfa_authenticator/views/settings_view/settings_view.dart';
 import 'package:edumfa_authenticator/views/tokens_view/tokens_view.dart';
 import 'package:edumfa_authenticator/views/view_interface.dart';
+import 'package:edumfa_authenticator/widgets/navigation_item.dart';
 import 'package:edumfa_authenticator/widgets/push_request_listener.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -52,24 +54,54 @@ class _MainViewState extends ConsumerState<MainView> with LifecycleMixin {
   Widget build(BuildContext context) {
     return PushRequestListener(
       child: Scaffold(
-        body: _views[_selectedIndex],
-        bottomNavigationBar: NavigationBar(
-          selectedIndex: _selectedIndex,
-          onDestinationSelected: _onDestinationSelected,
-          destinations: [
-            NavigationDestination(
-              icon: const Icon(Icons.home_outlined),
-              selectedIcon: const Icon(Icons.home),
-              label: S.of(context).tokens,
-            ),
-            NavigationDestination(
-              icon: const Icon(Icons.settings_outlined),
-              selectedIcon: const Icon(Icons.settings),
-              label: S.of(context).settings,
-            ),
-          ],
-        ),
+        body: isTablet(context)
+            ? Row(
+                children: <Widget>[
+                  NavigationRail(
+                    selectedIndex: _selectedIndex,
+                    onDestinationSelected: _onDestinationSelected,
+                    destinations: _getNavigationItems(context)
+                        .map((item) => item.toRailDestination()).toList(),
+                    labelType: NavigationRailLabelType.all,
+                    groupAlignment: 0,
+                  ),
+                  Expanded(
+                    child: ColoredBox(
+                      color: Colors.black,
+                      child: SafeArea(
+                        bottom: false,
+                        child: ClipRRect(
+                            borderRadius: const BorderRadius.vertical(top: Radius.circular(16.0)),
+                            child: _views[_selectedIndex],
+                        ),
+                      ),
+                    )
+                  ),
+                ],
+            )
+            : _views[_selectedIndex],
+        bottomNavigationBar: !isTablet(context)
+            ? NavigationBar(
+                selectedIndex: _selectedIndex,
+                onDestinationSelected: _onDestinationSelected,
+                destinations: _getNavigationItems(context)
+                    .map((item) => item.toDestination()).toList(),
+            )
+            : null,
       ),
     );
   }
+
+  List<NavigationItem> _getNavigationItems(BuildContext context) => [
+    NavigationItem(
+      icon: Icons.home_outlined,
+      selectedIcon: Icons.home,
+      label: S.of(context).tokens,
+    ),
+    NavigationItem(
+      icon: Icons.settings_outlined,
+      selectedIcon: Icons.settings,
+      label: S.of(context).settings,
+    ),
+  ];
 }

--- a/lib/widgets/navigation_item.dart
+++ b/lib/widgets/navigation_item.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+
+class NavigationItem {
+  final IconData icon;
+  final IconData selectedIcon;
+  final String label;
+
+  NavigationItem({
+    required this.icon,
+    required this.selectedIcon,
+    required this.label,
+  });
+
+  NavigationRailDestination toRailDestination() {
+    return NavigationRailDestination(
+      icon: Icon(icon),
+      selectedIcon: Icon(selectedIcon),
+      label: Text(label),
+    );
+  }
+
+  NavigationDestination toDestination() {
+    return NavigationDestination(
+      icon: Icon(icon),
+      selectedIcon: Icon(selectedIcon),
+      label: label,
+    );
+  }
+}


### PR DESCRIPTION
The app is currently built for portait usage on smartphone-like screens (width wise). This PR is an attempt to make the feel nice on tablets and foldables in particular.

## How to detect such device?
We currently apply a check of `MediaQuery.of(context).size.shortestSide > 600`. This checks if the device's shortest side is larger than 600. This value was chosen in particular, since it's commonly used.

## What needs to be changed?
- [x] (bottom) navigation bar needs to become a navigation rail
- [ ] We can display the tokens in a grid, instead of a list
- [ ] We need to verify the alert boxes to be properly sized
- [ ]  We could consider adjusting the search bar