### PR TITLE
Fix push signature verification: include question in the signed string

### DIFF
--- a/lib/model/push_request.dart
+++ b/lib/model/push_request.dart
@@ -15,6 +15,7 @@ class PushRequest {
   final DateTime expirationDate;
   final String serial;
   final String signature;
+  final String question;
   final bool? accepted;
 
   const PushRequest({
@@ -26,9 +27,11 @@ class PushRequest {
     required this.expirationDate,
     String? serial,
     String? signature,
+    String? question,
     this.accepted,
   })  : serial = serial ?? '',
-        signature = signature ?? '';
+        signature = signature ?? '',
+        question = question ?? '';
 
   PushRequest copyWith({
     String? title,
@@ -39,6 +42,7 @@ class PushRequest {
     DateTime? expirationDate,
     String? serial,
     String? signature,
+    String? question,
     bool? accepted,
   }) {
     return PushRequest(
@@ -50,6 +54,7 @@ class PushRequest {
       expirationDate: expirationDate ?? this.expirationDate,
       serial: serial ?? this.serial,
       signature: signature ?? this.signature,
+      question: question ?? this.question,
       accepted: accepted ?? this.accepted,
     );
   }
@@ -64,7 +69,7 @@ class PushRequest {
   String toString() {
     return 'PushRequest{title: $title, id: $id, uri: $uri, _nonce: $nonce, '
         'sslVerify: $sslVerify, expirationDate: $expirationDate, '
-        'serial: $serial, signature: $signature, accepted: $accepted}';
+        'serial: $serial, signature: $signature, question: $question, accepted: $accepted}';
   }
 
   factory PushRequest.fromJson(Map<String, dynamic> json) => _$PushRequestFromJson(json);
@@ -86,6 +91,7 @@ class PushRequest {
       serial: data[PUSH_REQUEST_SERIAL],
       expirationDate: DateTime.now().add(const Duration(minutes: 2)),
       signature: data[PUSH_REQUEST_SIGNATURE],
+      question: data[PUSH_REQUEST_QUESTION],
     );
   }
 

--- a/lib/model/push_request.g.dart
+++ b/lib/model/push_request.g.dart
@@ -15,6 +15,7 @@ PushRequest _$PushRequestFromJson(Map<String, dynamic> json) => PushRequest(
       expirationDate: DateTime.parse(json['expirationDate'] as String),
       serial: json['serial'] as String?,
       signature: json['signature'] as String?,
+      question: json['question'] as String?,
       accepted: json['accepted'] as bool?,
     );
 
@@ -28,5 +29,6 @@ Map<String, dynamic> _$PushRequestToJson(PushRequest instance) =>
       'expirationDate': instance.expirationDate.toIso8601String(),
       'serial': instance.serial,
       'signature': instance.signature,
+      'question': instance.question,
       'accepted': instance.accepted,
     };

--- a/lib/state_notifiers/token_notifier.dart
+++ b/lib/state_notifiers/token_notifier.dart
@@ -236,9 +236,12 @@ class TokenNotifier extends StateNotifier<TokenState> {
       return false;
     }
     String signature = pr.signature;
+    // Must match the server's sign_string in eduMFA pushtoken.py:
+    // "{nonce}|{url}|{serial}|{question}|{title}|{sslverify}"
     String signedData = '${pr.nonce}|'
         '${pr.uri}|'
         '${pr.serial}|'
+        '${pr.question}|'
         '${pr.title}|'
         '${pr.sslVerify ? '1' : '0'}';
 

--- a/lib/utils/identifiers.dart
+++ b/lib/utils/identifiers.dart
@@ -58,3 +58,4 @@ const String PUSH_REQUEST_SERIAL = 'serial'; // 3.
 const String PUSH_REQUEST_TITLE = 'title'; // 4.
 const String PUSH_REQUEST_SSL_VERIFY = 'sslverify'; // 5.
 const String PUSH_REQUEST_SIGNATURE = 'signature'; // 6.
+const String PUSH_REQUEST_QUESTION = 'question'; // 7.


### PR DESCRIPTION
The eduMFA server signs the push challenge as
{nonce}|{url}|{serial}|{question}|{title}|{sslverify} (6 fields). Upstream
commit 031858d ("Remove question from push request payload and replace it
with a static localizable question") dropped question from the payload and,
with it, from the signed-string reconstruction. The app now rebuilds only
5 fields, so the RSA signature of every incoming challenge fails to verify,
the request is rejected before the dialog is shown, and push approval is
impossible against a stock eduMFA server.

Re-add question to PushRequest (model, JSON, identifier) and insert it into
the signed string in the position the server uses. The on-screen text stays
the static localized question introduced by 031858d; question is used only
to reconstruct the signed payload, not for display.