### PR TITLE
Add complete Czech (cs) localization

### DIFF
--- a/lib/generated/intl/messages_cs.dart
+++ b/lib/generated/intl/messages_cs.dart
@@ -45,9 +45,17 @@ class MessageLookup extends MessageLookupByLibrary {
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
     "accept": MessageLookupByLibrary.simpleMessage("Přijmout"),
     "addToken": MessageLookupByLibrary.simpleMessage("Přidat token"),
+    "addTokenSubtitle": MessageLookupByLibrary.simpleMessage(
+      "Namiřte fotoaparát na obrazovku a naskenujte QR kód",
+    ),
+    "addTokenTitle": MessageLookupByLibrary.simpleMessage(
+      "Spárovat nový push token",
+    ),
     "allTokensSynchronized": MessageLookupByLibrary.simpleMessage(
       "Všechny tokeny jsou synchronizované.",
     ),
+    "appVersion": MessageLookupByLibrary.simpleMessage("Verze aplikace"),
+    "appearance": MessageLookupByLibrary.simpleMessage("Vzhled"),
     "authNotSupportedBody": MessageLookupByLibrary.simpleMessage(
       "Tato akce vyžaduje, aby bylo zařízení chráněno zámkem zařízení nebo biometrickým ověřením.",
     ),
@@ -56,12 +64,16 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "authRequest": MessageLookupByLibrary.simpleMessage("Žádost o ověření"),
     "authRequestInfo": m0,
+    "authRequestQuestion": MessageLookupByLibrary.simpleMessage(
+      "Chcete potvrdit žádost o ověření?",
+    ),
     "authToAcceptPushRequest": MessageLookupByLibrary.simpleMessage(
       "Pro přijetí požadavku na push notifikaci se přihlaste.",
     ),
     "authToDeclinePushRequest": MessageLookupByLibrary.simpleMessage(
       "Pro odmítnutí požadavku na push notifikaci se přihlaste.",
     ),
+    "autoTheme": MessageLookupByLibrary.simpleMessage("Automaticky"),
     "biometricHint": MessageLookupByLibrary.simpleMessage(
       "Vyžadováno přihlášení",
     ),
@@ -73,6 +85,9 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "biometricSuccess": MessageLookupByLibrary.simpleMessage(
       "Přihlášení bylo úspěšné",
+    ),
+    "cameraPermissionPermanentlyDenied": MessageLookupByLibrary.simpleMessage(
+      "Přístup k fotoaparátu byl trvale odepřen. Povolte jej prosím v nastavení systému.",
     ),
     "cameraPermissionPermanentlyDeniedButton":
         MessageLookupByLibrary.simpleMessage("Udělit oprávnění"),
@@ -126,6 +141,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "editLockedToken": MessageLookupByLibrary.simpleMessage(
       "Prosím, autentifikujte se pro úpravu uzamčeného tokenu.",
     ),
+    "editToken": MessageLookupByLibrary.simpleMessage("Upravit token"),
     "enablePolling": MessageLookupByLibrary.simpleMessage("Povolit polling"),
     "errorMailBody": MessageLookupByLibrary.simpleMessage(
       "Přiložen je soubor protokolu o chybách.\nTento text můžete nahradit dalšími informacemi o chybě.",
@@ -145,6 +161,7 @@ class MessageLookup extends MessageLookupByLibrary {
         ),
     "errorTokenExpired": m5,
     "errorWhenPullingChallenges": m6,
+    "feedback": MessageLookupByLibrary.simpleMessage("Zpětná vazba"),
     "generatingPhonePart": MessageLookupByLibrary.simpleMessage(
       "Generování klientské části",
     ),
@@ -154,6 +171,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "generatingRSAKeyPairFailed": MessageLookupByLibrary.simpleMessage(
       "Generování páru klíčů RSA se nezdařilo",
     ),
+    "github": MessageLookupByLibrary.simpleMessage("GitHub"),
     "goToSettingsButton": MessageLookupByLibrary.simpleMessage(
       "Otevřít nastavení",
     ),
@@ -161,12 +179,20 @@ class MessageLookup extends MessageLookupByLibrary {
       "Není nastaveno přihlášení zámkem zařízení ani biometrické ověření. Aktivujte je v nastavení zařízení.",
     ),
     "language": MessageLookupByLibrary.simpleMessage("Jazyk"),
+    "licenses": MessageLookupByLibrary.simpleMessage("Licence open source"),
     "lightTheme": MessageLookupByLibrary.simpleMessage("Světlý"),
     "lock": MessageLookupByLibrary.simpleMessage("Zamknout"),
+    "lockDescription": MessageLookupByLibrary.simpleMessage(
+      "Zamknout token biometrickým ověřením.",
+    ),
     "lockOut": MessageLookupByLibrary.simpleMessage(
       "Biometrické ověření je deaktivováno. Pro aktivaci zamkněte a znovu odemkněte obrazovku/zařízení.",
     ),
     "name": MessageLookupByLibrary.simpleMessage("Název"),
+    "nameFieldEmpty": MessageLookupByLibrary.simpleMessage(
+      "Název nesmí být prázdný",
+    ),
+    "next": MessageLookupByLibrary.simpleMessage("Další"),
     "noMailAppDescription": MessageLookupByLibrary.simpleMessage(
       "There is no e-mail app installed or initialised on this device, please try again when you are able to send an email message.",
     ),
@@ -185,6 +211,9 @@ class MessageLookup extends MessageLookupByLibrary {
     "noResultTitle": MessageLookupByLibrary.simpleMessage(
       "Nejsou nainstalovány žádné tokeny.",
     ),
+    "noSettingsSelected": MessageLookupByLibrary.simpleMessage(
+      "Vyberte nastavení",
+    ),
     "onBoardingText1": MessageLookupByLibrary.simpleMessage(
       "vícefázové ověření\nusnadněno",
     ),
@@ -200,6 +229,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "onBoardingTitle3": MessageLookupByLibrary.simpleMessage(
       "Navštivte náš profil Github",
     ),
+    "or": MessageLookupByLibrary.simpleMessage("NEBO"),
     "parsingResponse": MessageLookupByLibrary.simpleMessage("Rozbor odpovědi"),
     "parsingResponseFailed": MessageLookupByLibrary.simpleMessage(
       "Parsování odpovědi se nezdařilo",
@@ -222,6 +252,8 @@ class MessageLookup extends MessageLookupByLibrary {
     "rolloutCompleted": MessageLookupByLibrary.simpleMessage(
       "Zavedení dokončeno",
     ),
+    "saveChanges": MessageLookupByLibrary.simpleMessage("Uložit změny"),
+    "search": MessageLookupByLibrary.simpleMessage("Hledat"),
     "secretKey": MessageLookupByLibrary.simpleMessage("Tajný klíč"),
     "send": MessageLookupByLibrary.simpleMessage("Odeslat"),
     "sendErrorLogDescription": MessageLookupByLibrary.simpleMessage(
@@ -256,11 +288,14 @@ class MessageLookup extends MessageLookupByLibrary {
       "Tokeny se synchronizují.",
     ),
     "theme": MessageLookupByLibrary.simpleMessage("Vzhled"),
+    "tokens": MessageLookupByLibrary.simpleMessage("Tokeny"),
     "tokensDoNotSupportSynchronization": MessageLookupByLibrary.simpleMessage(
       "Následující tokeny nepodporují synchronizaci a musí být znovu zaregistrovány:",
     ),
     "unexpectedError": MessageLookupByLibrary.simpleMessage(
       "Nastala neočekávaná chyba.",
     ),
+    "uploadQrCodeButton": MessageLookupByLibrary.simpleMessage("Nahrát QR kód"),
+    "website": MessageLookupByLibrary.simpleMessage("Webové stránky"),
   };
 }

--- a/lib/l10n/intl_cs.arb
+++ b/lib/l10n/intl_cs.arb
@@ -12,7 +12,7 @@
   "@decline": {
     "description": "Label for e.g. a button. Something gets declined by the user."
   },
-  "editToken": null,
+  "editToken": "Upravit token",
   "@editToken": {
     "description": "Title of the edit token sheet."
   },
@@ -20,7 +20,7 @@
   "@name": {
     "description": "Describes the field where the tokens name should be entered."
   },
-  "nameFieldEmpty": null,
+  "nameFieldEmpty": "Název nesmí být prázdný",
   "@nameFieldEmpty": {
     "description": "Error message when the name field is empty."
   },
@@ -36,7 +36,7 @@
   "@delete": {
     "description": "Label that describes deleting the token."
   },
-  "saveChanges": null,
+  "saveChanges": "Uložit změny",
   "@saveChanges": {
     "description": "Label that describes saving changes to a token."
   },
@@ -44,7 +44,7 @@
   "@dismiss": {
     "description": "Text of a button that closes a dialog."
   },
-  "next": null,
+  "next": "Další",
   "@next": {
     "description": "Text of a button that goes to the next page."
   },
@@ -52,19 +52,19 @@
   "@addToken": {
     "description": "The button to open the screen to add tokens by hand."
   },
-  "addTokenTitle": null,
+  "addTokenTitle": "Spárovat nový push token",
   "@addTokenTitle": {
     "description": "The title of the token add screen."
   },
-  "addTokenSubtitle": null,
+  "addTokenSubtitle": "Namiřte fotoaparát na obrazovku a naskenujte QR kód",
   "@addTokenSubtitle": {
     "description": "The subtitle of the token add screen."
   },
-  "or": null,
+  "or": "NEBO",
   "@or": {
     "description": "This is shown as a splitter between the option to add a new token by either scanning a QR code OR uploading one as a file."
   },
-  "uploadQrCodeButton": null,
+  "uploadQrCodeButton": "Nahrát QR kód",
   "@uploadQrCodeButton": {
     "description": "The button in the token add view to upload QR codes as an image."
   },
@@ -94,7 +94,7 @@
   "@phonePart": {
     "description": "Title of a dialog telling the user that the phone was generated, and it is shown to the user."
   },
-  "tokens": null,
+  "tokens": "Tokeny",
   "@tokens": {
     "description": "Button to open the tokens page."
   },
@@ -102,11 +102,11 @@
   "@settings": {
     "description": "Button to open the settings page."
   },
-  "noSettingsSelected": null,
+  "noSettingsSelected": "Vyberte nastavení",
   "@noSettingsSelected": {
     "description": "Message when no setting is selected on tablets."
   },
-  "appearance": null,
+  "appearance": "Vzhled",
   "@appearance": {
     "description": "Title of the setting group where the theme can be selected."
   },
@@ -126,7 +126,7 @@
   "@darkTheme": {
     "description": "The dark theme."
   },
-  "autoTheme": null,
+  "autoTheme": "Automaticky",
   "@autoTheme": {
     "description": "The automatic theme applied by the system settings."
   },
@@ -292,11 +292,11 @@
   "@lock": {
     "description": "Description of button that locks a token."
   },
-  "lockDescription": null,
+  "lockDescription": "Zamknout token biometrickým ověřením.",
   "@lockDescription": {
     "description": "Description of the lock option when editing a token."
   },
-  "search": null,
+  "search": "Hledat",
   "@search": {
     "description": "Placeholder text for search bar."
   },
@@ -389,7 +389,7 @@
       }
     }
   },
-  "cameraPermissionPermanentlyDenied": null,
+  "cameraPermissionPermanentlyDenied": "Přístup k fotoaparátu byl trvale odepřen. Povolte jej prosím v nastavení systému.",
   "cameraPermissionPermanentlyDeniedButton": "Udělit oprávnění",
   "decryptErrorTitle": "Chyba dešifrování",
   "decryptErrorContent": "Bohužel se aplikaci nepodařilo dešifrovat vaše tokeny. To znamená, že šifrovací klíč je poškozen. Můžete to zkusit znovu nebo odstranit data aplikace, čímž by došlo k odstranění tokenů v aplikaci.",
@@ -397,15 +397,15 @@
   "decryptErrorButtonSendError": "Odeslat chybu",
   "decryptErrorButtonRetry": "Opakování",
   "decryptErrorDeleteConfirmationContent": "Jste si jisti, že chcete data aplikace odstranit?",
-  "licenses": null,
+  "licenses": "Licence open source",
   "@licenses": {
     "description": "Button to open the licenses page"
   },
-  "appVersion": null,
+  "appVersion": "Verze aplikace",
   "@appVersion": {
     "description": "App version info in the About page"
   },
-  "feedback": null,
+  "feedback": "Zpětná vazba",
   "@feedback": {
     "description": "Feedback button in the about page"
   },
@@ -413,11 +413,11 @@
   "@privacyPolicy": {
     "description": "Button to open the privacy policy"
   },
-  "website": null,
+  "website": "Webové stránky",
   "@website": {
     "description": "Button to open the website"
   },
-  "github": null,
+  "github": "GitHub",
   "@github": {
     "description": "Button to open the GitHub page"
   },
@@ -439,7 +439,7 @@
       }
     }
   },
-  "authRequestQuestion": null,
+  "authRequestQuestion": "Chcete potvrdit žádost o ověření?",
   "@authRequestQuestion": {
     "description": "Question of the push request dialog."
   }


### PR DESCRIPTION
Czech is a registered locale but 21 strings were left untranslated in
intl_cs.arb and fell back to English at runtime (settings, token add/edit,
and the push confirmation question). Translate them and regenerate the cs
messages.